### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,46 @@
+name: Bug Report
+description: Report issues with the module
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide the following version information.
+  - type: input
+    id: module-version
+    attributes:
+      label: Module version
+      description: Version of PF1 Improved Conditions
+    validations:
+      required: true
+  - type: input
+    id: foundry-version
+    attributes:
+      label: Foundry version
+    validations:
+      required: true
+  - type: input
+    id: system-version
+    attributes:
+      label: PF1e system version
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Describe how to reproduce the issue
+    validations:
+      required: true
+  - type: textarea
+    id: module-settings
+    attributes:
+      label: Relevant module settings
+      description: Include any pertinent configuration
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected vs. actual behavior
+      description: What did you expect to happen and what occurred instead?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,16 @@
+name: Feature Request
+description: Suggest an enhancement for the module
+labels: enhancement
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the feature or improvement you would like to see
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Thank you for your interest in improving this module. Issues and pull requests are welcome!
+
+## Reporting Bugs
+
+Please use the [Bug Report issue template](.github/ISSUE_TEMPLATE/bug-report.yml) and include version information and steps to reproduce the problem.
+
+## Requesting Features
+
+Enhancement ideas can be submitted through the [Feature Request issue template](.github/ISSUE_TEMPLATE/feature-request.yml). Include a clear description and any relevant context.
+


### PR DESCRIPTION
## Summary
- add bug-report and feature-request templates for GitHub issues
- document how to contribute and where to file issues

## Testing
- `git status --short`
